### PR TITLE
fix mate-bluetooth-properties.desktop

### DIFF
--- a/properties/mate-bluetooth-properties.desktop.in.in
+++ b/properties/mate-bluetooth-properties.desktop.in.in
@@ -1,11 +1,12 @@
 [Desktop Entry]
-_Name=Bluetooth
+_Name=Mate-Bluetooth
+_GenericName=Bluetooth
 _Comment=Configure Bluetooth settings
 Icon=bluetooth
 Exec=mate-bluetooth-properties
 Terminal=false
 Type=Application
-Categories=GTK;MATE;Settings;X-MATE-NetworkSettings;
+Categories=GTK;Settings;X-MATE-NetworkSettings;
 OnlyShowIn=MATE;
 StartupNotify=true
 X-MATE-Bugzilla-Bugzilla=MATE

--- a/properties/mate-bluetooth-properties.desktop.in.in
+++ b/properties/mate-bluetooth-properties.desktop.in.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-_Name=Mate-Bluetooth
+_Name=MATE-Bluetooth
 _GenericName=Bluetooth
 _Comment=Configure Bluetooth settings
 Icon=bluetooth


### PR DESCRIPTION
change name to Mate-Bluetooth
add generic name
remove category MATE
